### PR TITLE
Log out a de-authorized user

### DIFF
--- a/oh_data_source/views.py
+++ b/oh_data_source/views.py
@@ -99,9 +99,14 @@ def home(request):
                'oh_proj_page': settings.OH_ACTIVITY_PAGE}
 
     if request.user.is_authenticated:
-        context.update({
-            'oh_data': oh_get_member_data(
+        try:
+            oh_data = oh_get_member_data(
                 request.user.openhumansmember.get_access_token())
+        except Exception:
+            logout(request)
+            return redirect('home')
+        context.update({
+            'oh_data': oh_data,
         })
 
     return render(request, 'oh_data_source/index.html', context=context)


### PR DESCRIPTION
Currently the app experiences an error attempting to
use a token that's no longer valid. This change logs
the user out of the app and redirects them to the home
page (where they can re-authorize the app, if desired).